### PR TITLE
Port tint fix from p5.play repo

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -113,7 +113,7 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
   this._tintCanvas.width = img.canvas.width;
   this._tintCanvas.height = img.canvas.height;
   var tmpCtx = this._tintCanvas.getContext('2d');
-  tmpCtx.fillStyle = 'hsl(' + this._pInst.hue(this._tint) + ', 100%, 50%)';
+  tmpCtx.fillStyle = 'rgba(' + this._tint.join(', ') + ')';
   tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
   tmpCtx.globalCompositeOperation = 'destination-atop';
   tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width,


### PR DESCRIPTION
The version of p5.js we use in the main repo [actually comes from the p5.play lib directory](https://github.com/code-dot-org/code-dot-org/blob/f12e043ab00a22d2eda8e206e52d5ad6392b6ecf/apps/Gruntfile.js#L223-L230) 🤔. In order to fix that to point to this repo, first need to port over any changes. Luckily there's only one:

![image](https://user-images.githubusercontent.com/413693/63184547-68172a80-c00c-11e9-9c9d-2a5b39028606.png)

Ref: https://github.com/code-dot-org/p5.play/pull/46